### PR TITLE
fix: resolve Gradio 502 startup error on WSL2 environments

### DIFF
--- a/app_texturing.py
+++ b/app_texturing.py
@@ -1,4 +1,5 @@
 import gradio as gr
+import argparse
 
 import os
 os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
@@ -143,9 +144,43 @@ with gr.Blocks(delete_cache=(600, 600)) as demo:
 
 # Launch the Gradio app
 if __name__ == "__main__":
+    # Parse command line arguments for server configuration
+    parser = argparse.ArgumentParser(description='TRELLIS.2 Texturing Demo')
+    parser.add_argument('--server-name', type=str, default=None,
+                        help='Server name/IP to bind to. Use "0.0.0.0" for WSL2 or Docker environments.')
+    parser.add_argument('--server-port', type=int, default=7860,
+                        help='Port to run the server on (default: 7860)')
+    parser.add_argument('--share', action='store_true',
+                        help='Create a public Gradio share link')
+    args = parser.parse_args()
+
+    # Auto-detect WSL2 environment and set appropriate server_name
+    server_name = args.server_name
+    if server_name is None:
+        # Check if running in WSL2
+        is_wsl = False
+        try:
+            with open('/proc/version', 'r') as f:
+                is_wsl = 'microsoft' in f.read().lower() or 'wsl' in f.read().lower()
+        except:
+            pass
+        
+        # Also check WSL_DISTRO_NAME environment variable
+        if os.environ.get('WSL_DISTRO_NAME') or os.environ.get('WSL_INTEROP'):
+            is_wsl = True
+        
+        if is_wsl:
+            server_name = "0.0.0.0"
+            print("WSL2 environment detected. Using server_name='0.0.0.0' for better compatibility.")
+            print("Access the app at http://localhost:{} from your Windows browser.".format(args.server_port))
+
     os.makedirs(TMP_DIR, exist_ok=True)
 
     pipeline = Trellis2TexturingPipeline.from_pretrained('microsoft/TRELLIS.2-4B', config_file="texturing_pipeline.json")
     pipeline.cuda()
     
-    demo.launch()
+    demo.launch(
+        server_name=server_name,
+        server_port=args.server_port,
+        share=args.share,
+    )


### PR DESCRIPTION
Hey! 👋

I ran into the issue described in #49 where the Gradio app crashes with a 502 error when running on WSL2. After some digging, I found the root cause and put together a fix.

## What was happening

On WSL2, when you run `python app.py`, it fails with:



The problem is that WSL2 handles localhost networking differently than native Linux. Gradio tries to verify the server is running by pinging `127.0.0.1`, but that doesn't work reliably in WSL2.

## What I changed

- Added auto-detection for WSL2 environments (checks `/proc/version` and env variables)
- When WSL2 is detected, the app automatically binds to `0.0.0.0` instead of localhost
- Added some command-line flags (`--server-name`, `--server-port`, `--share`) so users can manually configure things if needed
- Applied the same fix to `app_texturing.py` for consistency

## How to use it

For most people, it should just work now:
```bash
python app.py
