### PR TITLE
fix windows build

### DIFF
--- a/build_windows.bat
+++ b/build_windows.bat
@@ -141,10 +141,8 @@ if defined CUDA_PATH call set "PATH=%CUDA_PATH%\bin;%CUDA_PATH%\libnvvp;%PATH%"
 echo.
 echo %green%Building nvdiffrast...%reset%
 
-pushd nvdiffrast
 %PYTHON_PATH% -m pip uninstall -y nvdiffrast
 %PYTHON_PATH% -m pip install git+https://github.com/NVlabs/nvdiffrast.git --no-build-isolation --no-cache-dir
-popd
 
 echo %green%nvdiffrast build finished...%reset%
 
@@ -161,10 +159,8 @@ echo %green%Verifying nvdiffrast...%reset%
 echo.
 echo %green%Building FlexGEMM...%reset%
 
-pushd flexgemm
 %PYTHON_PATH% -m pip uninstall -y flex_gemm
 %PYTHON_PATH% -m pip install git+https://github.com/JeffreyXiang/FlexGEMM --no-build-isolation --no-cache-dir
-popd
 
 echo %green%FlexGEMM build finished...%reset%
 
@@ -174,10 +170,8 @@ echo %green%FlexGEMM build finished...%reset%
 echo.
 echo %green%Building CuMesh...%reset%
 
-pushd cumesh
 %PYTHON_PATH% -m pip uninstall -y cumesh
 %PYTHON_PATH% -m pip install git+https://github.com/JeffreyXiang/CuMesh --no-build-isolation --no-cache-dir
-popd
 
 echo %green%CuMesh build finished...%reset%
 
@@ -187,9 +181,9 @@ echo %green%CuMesh build finished...%reset%
 echo.
 echo %green%Building o_voxel...%reset%
 
-pushd trellis2\o-voxel
-%PYTHON_PATH% -m pip uninstall -y o_voxel
+pushd o-voxel
 git submodule update --init --recursive
+%PYTHON_PATH% -m pip uninstall -y o_voxel
 %PYTHON_PATH% setup.py install
 popd
 

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,0 +1,311 @@
+@echo off
+cd /d %~dp0
+Title Trellis2 BUILD (no wheels) (WINDOWS + Python 3.13 + Torch 2.9 + Cuda 13)
+
+setlocal EnableExtensions EnableDelayedExpansion
+call :set_colors
+
+echo %green%=====================================%reset%
+echo %green%   Building TRELLIS.2 (WINDOWS)     %reset%
+echo %green%=====================================%reset%
+echo.
+
+:: -------------------------------------------------
+:: Resolve Python
+:: -------------------------------------------------
+for %%P in (python.exe) do set "PYTHON_PATH=%%~$PATH:P"
+
+if not defined PYTHON_PATH (
+    echo %red%ERROR: Python not found in PATH%reset%
+    echo Install Python from https://www.python.org
+    exit /b 1
+)
+
+echo Using Python:
+%PYTHON_PATH% --version
+echo Location: %PYTHON_PATH%
+echo.
+
+:: -------------------------------------------------
+:: Version checks
+:: -------------------------------------------------
+call :get_versions
+
+if not "%PYTHON_VERSION%"=="3.13" (
+    echo %red%ERROR: Python 3.13 is required%reset%
+    exit /b 1
+)
+
+if not "%TORCH_VERSION%"=="2.9" (
+    echo %red%ERROR: Torch 2.9.x required%reset%
+    echo Detected Torch: %TORCH_VERSION%
+    exit /b 1
+)
+
+if not "%CUDA_VERSION%"=="13.0" (
+    echo %red%ERROR: CUDA 13.0 required%reset%
+    echo Detected CUDA: %CUDA_VERSION%
+    exit /b 1
+)
+
+:: -------------------------------------------------
+:: Preconditions
+:: -------------------------------------------------
+echo Assumptions:
+echo - Torch 2.9.1 + cu130 already installed
+echo - CUDA Toolkit 13.0 installed (nvcc available)
+echo - VC++ Redistributable installed
+echo.
+
+where nvcc
+if errorlevel 1 (
+    echo %yellow%WARNING: nvcc not found in PATH%reset%
+    echo FlashAttention build may fail
+)
+echo.
+
+:: ===============================
+:: MSVC (Visual Studio Build Tools)
+:: ===============================
+echo.
+echo ===============================================
+echo   Configuring MSVC toolchain
+echo ===============================================
+echo.
+
+set "MSVC_VCVARS=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+
+echo Using MSVC environment script:
+echo   %MSVC_VCVARS%
+echo.
+
+if not exist "%MSVC_VCVARS%" (
+    echo ERROR: MSVC vcvars64.bat not found
+    echo.
+    echo Expected location:
+    echo   %MSVC_VCVARS%
+    echo.
+    echo If your Visual Studio is installed elsewhere, edit this path in the script.
+    echo Required components:
+    echo   - Desktop development with C++
+    echo   - MSVC v143 build tools
+    echo   - Windows 10/11 SDK
+    echo.
+    exit /b 1
+)
+
+call "%MSVC_VCVARS%"
+
+:: ===============================
+:: BUILD FLAGS
+:: ===============================
+set DISTUTILS_USE_SDK=1
+set MSSdk=1
+set USE_NINJA=1
+set MAX_JOBS=16
+set CMAKE_BUILD_PARALLEL_LEVEL=16
+
+echo.
+echo Building with:
+echo   DISTUTILS_USE_SDK=%DISTUTILS_USE_SDK%
+echo   MSSdk=%MSSdk%
+echo   USE_NINJA=%USE_NINJA%
+echo   MAX_JOBS=%MAX_JOBS%
+echo   CMAKE_BUILD_PARALLEL_LEVEL=%CMAKE_BUILD_PARALLEL_LEVEL%
+echo   TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%
+echo.
+
+:: -------------------------------------------------
+:: CUDA runtime DLL visibility (safe)
+:: -------------------------------------------------
+if defined CUDA_PATH call set "PATH=%CUDA_PATH%\bin;%CUDA_PATH%\libnvvp;%PATH%"
+
+:: ===============================
+:: TOOLS
+:: ===============================
+%PYTHON_PATH% -m pip install -U setuptools wheel ninja cmake pybind11 packaging
+
+:: ===============================
+:: RUNTIME DEPS
+:: ===============================
+%PYTHON_PATH% -m pip install ^
+  trimesh ^
+  shapely ^
+  rtree ^
+  easydict ^
+  plyfile ^
+  zstandard
+
+:: =================================================
+:: nvdiffrast
+:: =================================================
+echo.
+echo %green%Building nvdiffrast...%reset%
+
+%PYTHON_PATH% -m pip uninstall -y nvdiffrast
+rmdir /s /q "%PYTHON_PATH%\Lib\site-packages\nvdiffrast" 2>nul
+
+if not exist nvdiffrec (
+    git clone --recursive https://github.com/NVlabs/nvdiffrec.git || exit /b 1
+)
+
+pushd nvdiffrast
+%PYTHON_PATH% setup.py install
+popd
+
+echo %green%nvdiffrast build finished...%reset%
+
+echo.
+echo %green%Verifying nvdiffrast...%reset%
+%PYTHON_PATH% -c "import nvdiffrast.torch as dr; print('nvdiffrast.torch OK')" || (
+    echo %red%ERROR: nvdiffrast failed to load%reset%
+    exit /b 1
+)
+
+:: ===============================
+:: nvdiffrec (CODE ONLY)
+:: ===============================
+echo.
+echo %yellow%Cloning nvdiffrec (code-only, no build step)...%reset%
+
+if not exist nvdiffrec (
+    git clone --recursive https://github.com/NVlabs/nvdiffrec.git || exit /b 1
+)
+
+echo %green%nvdiffrec cloned successfully...%reset%
+
+:: ===============================
+:: FlexGEMM
+:: ===============================
+echo.
+echo %green%Building FlexGEMM...%reset%
+
+if not exist FlexGEMM (
+  git clone https://github.com/gustavomassa/FlexGEMM flexgemm || exit /b 1
+)
+
+pushd flexgemm
+%PYTHON_PATH% -m pip uninstall -y flex_gemm
+%PYTHON_PATH% -m pip install . --no-build-isolation
+popd
+
+echo %green%FlexGEMM build finished...%reset%
+
+:: ===============================
+:: CuMesh
+:: ===============================
+echo.
+echo %green%Building CuMesh...%reset%
+
+if not exist cumesh (
+  git clone --recursive https://github.com/gustavomassa/CuMesh cumesh || exit /b 1
+)
+pushd cumesh
+%PYTHON_PATH% -m pip uninstall -y cumesh
+%PYTHON_PATH% setup.py install
+popd
+
+echo %green%CuMesh build finished...%reset%
+
+:: ===============================
+:: TRELLIS.2 (CODE ONLY)
+:: ===============================
+echo.
+echo %yellow%Cloning trellis2...%reset%
+
+if not exist trellis2 (
+  git clone --recursive https://github.com/gustavomassa/TRELLIS.2 trellis2 || exit /b 1
+)
+
+echo %green%trellis2 cloned successfully...%reset%
+
+:: ===============================
+:: o-voxel (Inside TRELLIS.2)
+:: ===============================
+echo.
+echo %green%Building o_voxel...%reset%
+
+pushd trellis2\o-voxel
+%PYTHON_PATH% -m pip uninstall -y o_voxel
+git submodule update --init --recursive
+%PYTHON_PATH% setup.py install
+popd
+
+echo %green%voxel build finished...%reset%
+
+echo.
+echo %green%Verifying voxel...%reset%
+%PYTHON_PATH% -c "import o_voxel; print('Voxel OK')" || (
+    echo %red%ERROR: Voxel failed to load%reset%
+    exit /b 1
+)
+
+:: =================================================
+:: Verification (core environment)
+:: =================================================
+echo.
+echo %green%Verifying core environment...%reset%
+
+%PYTHON_PATH% -c "import torch,numpy; print('Torch:',torch.__version__); print('CUDA:',torch.cuda.is_available()); print('NumPy:',numpy.__version__)" || (
+    echo %red%ERROR: Core env failed%reset%
+    exit /b 1
+)
+
+:: =================================================
+:: Verification (native extensions)
+:: =================================================
+echo.
+echo %green%Verifying native extensions (best-effort)...%reset%
+
+set "VERIFY_PY=%TEMP%\verify_native_ext.py"
+
+echo import importlib > "%VERIFY_PY%"
+echo mods = [^('cumesh','CuMesh'^),^('flex_gemm','FlexGEMM'^),^('o_voxel','Voxel'^),^('nvdiffrast','nvdiffrast'^)] >> "%VERIFY_PY%"
+echo for m,n in mods: >> "%VERIFY_PY%"
+echo.    try: >> "%VERIFY_PY%"
+echo.        importlib.import_module(m) >> "%VERIFY_PY%"
+echo.        print('[OK]',n) >> "%VERIFY_PY%"
+echo.    except Exception as e: >> "%VERIFY_PY%"
+echo.        print('[WARN]',n,'FAILED',e) >> "%VERIFY_PY%"
+
+%PYTHON_PATH% "%VERIFY_PY%"
+del "%VERIFY_PY%"
+
+echo.
+echo %green%=====================================%reset%
+echo %green%   TRELLIS.2 INSTALL COMPLETE         %reset%
+echo %green%=====================================%reset%
+pause
+exit /b 0
+
+:: -------------------------------------------------
+:: Helpers
+:: -------------------------------------------------
+:set_colors
+set red=[91m
+set green=[92m
+set yellow=[93m
+set reset=[0m
+goto :eof
+
+:get_versions
+echo Checking versions...
+echo.
+
+for /f "tokens=2" %%i in ('"%PYTHON_PATH%" --version 2^>^&1') do (
+    for /f "tokens=1,2 delims=." %%a in ("%%i") do set PYTHON_VERSION=%%a.%%b
+)
+
+"%PYTHON_PATH%" -c "import torch; print(torch.__version__)" > temp_torch.txt
+for /f "tokens=1,2 delims=." %%a in (temp_torch.txt) do set TORCH_VERSION=%%a.%%b
+del temp_torch.txt
+
+"%PYTHON_PATH%" -c "import torch; print(torch.version.cuda)" > temp_cuda.txt
+for /f "tokens=1,2 delims=." %%a in (temp_cuda.txt) do set CUDA_VERSION=%%a.%%b
+del temp_cuda.txt
+
+echo Python: %PYTHON_VERSION%
+echo Torch : %TORCH_VERSION%
+echo CUDA  : %CUDA_VERSION%
+echo.
+goto :eof

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -112,7 +112,6 @@ echo   MSSdk=%MSSdk%
 echo   USE_NINJA=%USE_NINJA%
 echo   MAX_JOBS=%MAX_JOBS%
 echo   CMAKE_BUILD_PARALLEL_LEVEL=%CMAKE_BUILD_PARALLEL_LEVEL%
-echo   TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%
 echo.
 
 :: -------------------------------------------------
@@ -142,15 +141,9 @@ if defined CUDA_PATH call set "PATH=%CUDA_PATH%\bin;%CUDA_PATH%\libnvvp;%PATH%"
 echo.
 echo %green%Building nvdiffrast...%reset%
 
-%PYTHON_PATH% -m pip uninstall -y nvdiffrast
-rmdir /s /q "%PYTHON_PATH%\Lib\site-packages\nvdiffrast" 2>nul
-
-if not exist nvdiffrec (
-    git clone --recursive https://github.com/NVlabs/nvdiffrec.git || exit /b 1
-)
-
 pushd nvdiffrast
-%PYTHON_PATH% setup.py install
+%PYTHON_PATH% -m pip uninstall -y nvdiffrast
+%PYTHON_PATH% -m pip install git+https://github.com/NVlabs/nvdiffrast.git --no-build-isolation --no-cache-dir
 popd
 
 echo %green%nvdiffrast build finished...%reset%
@@ -163,30 +156,14 @@ echo %green%Verifying nvdiffrast...%reset%
 )
 
 :: ===============================
-:: nvdiffrec (CODE ONLY)
-:: ===============================
-echo.
-echo %yellow%Cloning nvdiffrec (code-only, no build step)...%reset%
-
-if not exist nvdiffrec (
-    git clone --recursive https://github.com/NVlabs/nvdiffrec.git || exit /b 1
-)
-
-echo %green%nvdiffrec cloned successfully...%reset%
-
-:: ===============================
 :: FlexGEMM
 :: ===============================
 echo.
 echo %green%Building FlexGEMM...%reset%
 
-if not exist FlexGEMM (
-  git clone https://github.com/gustavomassa/FlexGEMM flexgemm || exit /b 1
-)
-
 pushd flexgemm
 %PYTHON_PATH% -m pip uninstall -y flex_gemm
-%PYTHON_PATH% -m pip install . --no-build-isolation
+%PYTHON_PATH% -m pip install git+https://github.com/JeffreyXiang/FlexGEMM --no-build-isolation --no-cache-dir
 popd
 
 echo %green%FlexGEMM build finished...%reset%
@@ -197,30 +174,15 @@ echo %green%FlexGEMM build finished...%reset%
 echo.
 echo %green%Building CuMesh...%reset%
 
-if not exist cumesh (
-  git clone --recursive https://github.com/gustavomassa/CuMesh cumesh || exit /b 1
-)
 pushd cumesh
 %PYTHON_PATH% -m pip uninstall -y cumesh
-%PYTHON_PATH% setup.py install
+%PYTHON_PATH% -m pip install git+https://github.com/JeffreyXiang/CuMesh --no-build-isolation --no-cache-dir
 popd
 
 echo %green%CuMesh build finished...%reset%
 
 :: ===============================
-:: TRELLIS.2 (CODE ONLY)
-:: ===============================
-echo.
-echo %yellow%Cloning trellis2...%reset%
-
-if not exist trellis2 (
-  git clone --recursive https://github.com/gustavomassa/TRELLIS.2 trellis2 || exit /b 1
-)
-
-echo %green%trellis2 cloned successfully...%reset%
-
-:: ===============================
-:: o-voxel (Inside TRELLIS.2)
+:: o-voxel
 :: ===============================
 echo.
 echo %green%Building o_voxel...%reset%

--- a/o-voxel/setup.py
+++ b/o-voxel/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup
 from torch.utils.cpp_extension import CUDAExtension, BuildExtension, IS_HIP_EXTENSION
 import os
+import platform
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 BUILD_TARGET = os.environ.get("BUILD_TARGET", "auto")
@@ -21,6 +22,17 @@ if not IS_HIP:
 else:
     archs = os.getenv("GPU_ARCHS", "native").split(";")
     cc_flag = [f"--offload-arch={arch}" for arch in archs]
+
+if platform.system() == "Windows":
+    extra_compile_args = {
+        "cxx": ["/O2", "/std:c++17", "/EHsc", "/permissive-", "/Zc:__cplusplus"],
+        "nvcc": ["-O3", "-std=c++17", "-Xcompiler=/std:c++17", "-Xcompiler=/EHsc", "-Xcompiler=/permissive-", "-Xcompiler=/Zc:__cplusplus"] + cc_flag,
+    }
+else:
+    extra_compile_args = {
+        "cxx": ["-O2", "-std=c++17"],
+        "nvcc": ["-O3","-std=c++17"] + cc_flag
+    }
 
 setup(
     name="o_voxel",
@@ -55,10 +67,7 @@ setup(
             include_dirs=[
                 os.path.join(ROOT, "third_party/eigen"),
             ],
-            extra_compile_args={
-                "cxx": ["-O3", "-std=c++17"],
-                "nvcc": ["-O3","-std=c++17"] + cc_flag,
-            }
+            extra_compile_args=extra_compile_args
         )
     ],
     cmdclass={

--- a/o-voxel/setup.py
+++ b/o-voxel/setup.py
@@ -30,7 +30,7 @@ if platform.system() == "Windows":
     }
 else:
     extra_compile_args = {
-        "cxx": ["-O2", "-std=c++17"],
+        "cxx": ["-O3", "-std=c++17"],
         "nvcc": ["-O3","-std=c++17"] + cc_flag
     }
 

--- a/o-voxel/src/convert/flexible_dual_grid.cpp
+++ b/o-voxel/src/convert/flexible_dual_grid.cpp
@@ -304,7 +304,7 @@ void boundry_qef(
         // Calculate the QEF for the edge (boundary) defined by v0 and v1
         Eigen::Vector3d dir(v1.x() - v0.x(), v1.y() - v0.y(), v1.z() - v0.z());
         double segment_length = dir.norm();
-        if (segment_length < 1e-6d) continue; // Skip degenerate edges (zero-length)
+        if (segment_length < 1e-6) continue; // Skip degenerate edges (zero-length)
         dir.normalize();  // unit direction vector
 
         // Projection matrix orthogonal to the direction: I - d d^T
@@ -334,7 +334,7 @@ void boundry_qef(
 
         Eigen::Vector3d tMax, tDelta;
         for (int axis = 0; axis < 3; ++axis) {
-            if (dir[axis] == 0.0d) {
+            if (dir[axis] == 0.0) {
                 tMax[axis] = std::numeric_limits<double>::infinity();
                 tDelta[axis] = std::numeric_limits<double>::infinity();
             } else {

--- a/o-voxel/src/io/filter_neighbor.cpp
+++ b/o-voxel/src/io/filter_neighbor.cpp
@@ -77,7 +77,7 @@ torch::Tensor encode_sparse_voxel_octree_attr_neighbor_cpu(
     }
 
     // Pack the deltas into a uint8 tensor
-    torch::Tensor delta = torch::zeros({N, C}, torch::dtype(torch::kUInt8));
+    torch::Tensor delta = torch::zeros({static_cast<int64_t>(N), static_cast<int64_t>(C)}, torch::dtype(torch::kUInt8));
     uint8_t* delta_data = delta.data_ptr<uint8_t>();
     for (int i = 0; i < N; i++) {
         int x = coord_data[i * 3 + 0];
@@ -163,7 +163,7 @@ torch::Tensor decode_sparse_voxel_octree_attr_neighbor_cpu(
     }
 
     // Pack the attribute into a uint8 tensor
-    torch::Tensor attr = torch::zeros({N, C}, torch::dtype(torch::kUInt8));
+    torch::Tensor attr = torch::zeros({static_cast<int64_t>(N), static_cast<int64_t>(C)}, torch::dtype(torch::kUInt8));
     uint8_t* attr_data = attr.data_ptr<uint8_t>();
     for (int i = 0; i < N; i++) {
         int x = coord_data[i * 3 + 0];

--- a/o-voxel/src/io/filter_parent.cpp
+++ b/o-voxel/src/io/filter_parent.cpp
@@ -80,7 +80,7 @@ torch::Tensor encode_sparse_voxel_octree_attr_parent_cpu(
     uint8_t* octree_data = octree.data_ptr<uint8_t>();
     uint8_t* attr_data = attr.data_ptr<uint8_t>();
 
-    torch::Tensor delta = torch::zeros({N_leaf, C}, torch::kUInt8);
+    torch::Tensor delta = torch::zeros({static_cast<int64_t>(N_leaf), static_cast<int64_t>(C)}, torch::kUInt8);
     uint32_t svo_ptr = 0;
     uint32_t attr_ptr = 0;
     uint32_t delta_ptr = C;
@@ -151,7 +151,7 @@ torch::Tensor decode_sparse_voxel_octree_attr_parent_cpu(
     uint8_t* octree_data = octree.data_ptr<uint8_t>();
     uint8_t* delta_data = delta.data_ptr<uint8_t>();
 
-    torch::Tensor attr = torch::zeros({N_leaf, C}, torch::kUInt8);
+    torch::Tensor attr = torch::zeros({static_cast<int64_t>(N_leaf), static_cast<int64_t>(C)}, torch::kUInt8);
     uint32_t svo_ptr = 0;
     uint32_t attr_ptr = 0;
     uint32_t delta_ptr = C;

--- a/o-voxel/src/io/svo.cpp
+++ b/o-voxel/src/io/svo.cpp
@@ -71,7 +71,7 @@ torch::Tensor encode_sparse_voxel_octree_cpu(
     }
 
     // Convert SVO to tensor
-    torch::Tensor svo_tensor = torch::from_blob(svo.data(), {svo.size()}, torch::kUInt8).clone();
+    torch::Tensor svo_tensor = torch::from_blob(svo.data(), {static_cast<int64_t>(svo.size())}, torch::kUInt8).clone();
     return svo_tensor;
 }
 
@@ -133,6 +133,6 @@ torch::Tensor decode_sparse_voxel_octree_cpu(
     // Decode SVO into list of codes
     decode_sparse_voxel_octree_cpu_recursive(octree_data, depth, ptr, stack, codes);
     // Convert codes to tensor
-    torch::Tensor codes_tensor = torch::from_blob(codes.data(), {codes.size()}, torch::kInt32).clone();
+    torch::Tensor codes_tensor = torch::from_blob(codes.data(), {static_cast<int64_t>(codes.size())}, torch::kInt32).clone();
     return codes_tensor;
 }


### PR DESCRIPTION
Fix Windows build with modern CUDA / MSVC toolchain

### Problems

1. Windows builds use MSVC as the host compiler for NVCC, which is much stricter than GCC/Clang and behaves differently than Linux toolchains.
2. With CUDA 12+ and Torch 2.9, several headers (especially torch::dynamo and CUB) now rely on standard-compliant C++ detection that MSVC historically misreports unless explicitly instructed.
3. Some compilations errors about narrowing conversions

Modern Windows builds (Torch 2.9 + CUDA 12/13 + Python 3.13) require explicit compiler flags to make MSVC behave consistently with Linux toolchains

Also added a build_windows.bat script to build all dependencies(nvdiffrast, FlexGEMM, CuMesh, o-voxel)
Make sure you first merge these PR's:
https://github.com/JeffreyXiang/FlexGEMM/pull/11
https://github.com/JeffreyXiang/CuMesh/pull/21

### Tested on
- Windows 11
- MSVC 14.43 (VS2022)
- CUDA 13.0
- Python 3.13
- PyTorch 2.9

