### PR TITLE
fix: use specific exceptions and 'is None' per PEP 8

### DIFF
--- a/data_toolkit/blender_script/dump_pbr.py
+++ b/data_toolkit/blender_script/dump_pbr.py
@@ -412,7 +412,7 @@ def main(arg):
                     pack["roughnessTexture"] = image
 
             output['materials'].append(pack)
-        except:
+        except Exception:
             with open(arg.output_path + '_error.txt', 'w') as f:
                 f.write(str([[n.name] for n in mat.node_tree.nodes]))
             raise RuntimeError("Material is not supported")

--- a/data_toolkit/voxelize_pbr.py
+++ b/data_toolkit/voxelize_pbr.py
@@ -34,7 +34,7 @@ def _pbr_voxelize(file, metadatum, pbr_dump_root, root):
 
             # process if necessary
             if need_process:
-                if dump == None:
+                if dump is None:
                     with open(os.path.join(pbr_dump_root, 'pbr_dumps', f'{sha256}.pickle'), 'rb') as f:
                         dump = pickle.load(f)
                     # Fix dump alpha map

--- a/trellis2/datasets/components.py
+++ b/trellis2/datasets/components.py
@@ -25,7 +25,7 @@ class StandardDatasetBase(Dataset):
         try:
             self.roots = json.loads(roots)
             root_type = 'obj'
-        except:
+        except (json.JSONDecodeError, ValueError):
             self.roots = roots.split(',')
             root_type = 'list'
         self.instances = []

--- a/trellis2/modules/sparse/basic.py
+++ b/trellis2/modules/sparse/basic.py
@@ -203,7 +203,7 @@ class VarLenTensor:
             try:
                 other = torch.broadcast_to(other, self.shape)
                 other = other[self.batch_boardcast_map]
-            except:
+            except (RuntimeError, IndexError):
                 pass
         if isinstance(other, VarLenTensor):
             other = other.feats
@@ -719,7 +719,7 @@ class SparseTensor(VarLenTensor):
             try:
                 other = torch.broadcast_to(other, self.shape)
                 other = other[self.batch_boardcast_map]
-            except:
+            except (RuntimeError, IndexError):
                 pass
         if isinstance(other, VarLenTensor):
             other = other.feats


### PR DESCRIPTION
## Changes

| File | Before | After |
|------|--------|-------|
| `dump_pbr.py` | `except:` | `except Exception:` |
| `components.py` | `except:` | `except (json.JSONDecodeError, ValueError):` |
| `basic.py` (2x) | `except:` | `except (RuntimeError, IndexError):` |
| `voxelize_pbr.py` | `== None` | `is None` |