### PR TITLE
fix: replace 4 bare except clauses with except Exception

### DIFF
--- a/data_toolkit/blender_script/dump_pbr.py
+++ b/data_toolkit/blender_script/dump_pbr.py
@@ -412,7 +412,7 @@ def main(arg):
                     pack["roughnessTexture"] = image
 
             output['materials'].append(pack)
-        except:
+        except Exception:
             with open(arg.output_path + '_error.txt', 'w') as f:
                 f.write(str([[n.name] for n in mat.node_tree.nodes]))
             raise RuntimeError("Material is not supported")

--- a/trellis2/datasets/components.py
+++ b/trellis2/datasets/components.py
@@ -25,7 +25,7 @@ class StandardDatasetBase(Dataset):
         try:
             self.roots = json.loads(roots)
             root_type = 'obj'
-        except:
+        except Exception:
             self.roots = roots.split(',')
             root_type = 'list'
         self.instances = []

--- a/trellis2/modules/sparse/basic.py
+++ b/trellis2/modules/sparse/basic.py
@@ -203,7 +203,7 @@ class VarLenTensor:
             try:
                 other = torch.broadcast_to(other, self.shape)
                 other = other[self.batch_boardcast_map]
-            except:
+            except Exception:
                 pass
         if isinstance(other, VarLenTensor):
             other = other.feats
@@ -719,7 +719,7 @@ class SparseTensor(VarLenTensor):
             try:
                 other = torch.broadcast_to(other, self.shape)
                 other = other[self.batch_boardcast_map]
-            except:
+            except Exception:
                 pass
         if isinstance(other, VarLenTensor):
             other = other.feats


### PR DESCRIPTION
## What
Replace 4 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.