### PR TITLE
Fix dtype mismatches for GPUs without bfloat16 support

### DIFF
--- a/trellis2/models/sparse_structure_flow.py
+++ b/trellis2/models/sparse_structure_flow.py
@@ -49,6 +49,7 @@ class TimestepEmbedder(nn.Module):
 
     def forward(self, t):
         t_freq = self.timestep_embedding(t, self.frequency_embedding_size)
+        t_freq = t_freq.to(self.mlp[0].weight.dtype)
         t_emb = self.mlp(t_freq)
         return t_emb
 

--- a/trellis2/pipelines/rembg/BiRefNet.py
+++ b/trellis2/pipelines/rembg/BiRefNet.py
@@ -7,17 +7,34 @@ from PIL import Image
 
 class BiRefNet:
     def __init__(self, model_name: str = "ZhengPeng7/BiRefNet"):
+        # Ensure compatibility with transformers 5.x before loading:
+        # 1. Patch missing all_tied_weights_keys attribute
+        # 2. Skip meta device init (BiRefNet's __init__ calls .item() which is incompatible)
+        from transformers.dynamic_module_utils import get_class_from_dynamic_module
+        try:
+            birefnet_cls = get_class_from_dynamic_module(
+                "birefnet.BiRefNet", model_name
+            )
+            if not hasattr(birefnet_cls, 'all_tied_weights_keys'):
+                birefnet_cls.all_tied_weights_keys = {}
+
+            @classmethod
+            def _no_meta_init_context(cls, dtype, is_quantized, _is_ds_init_called, allow_all_kernels):
+                from transformers.modeling_utils import local_torch_dtype, init, apply_patches
+                return [local_torch_dtype(dtype, cls.__name__), init.no_tie_weights(), apply_patches()]
+            birefnet_cls.get_init_context = _no_meta_init_context
+        except Exception:
+            pass
+
         self.model = AutoModelForImageSegmentation.from_pretrained(
             model_name, trust_remote_code=True
         )
         self.model.eval()
-        self.transform_image = transforms.Compose(
-            [
-                transforms.Resize((1024, 1024)),
-                transforms.ToTensor(),
-                transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
-            ]
-        )
+        self.transform_image = transforms.Compose([
+            transforms.Resize((1024, 1024)),
+            transforms.ToTensor(),
+            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+        ])
     
     def to(self, device: str):
         self.model.to(device)

--- a/trellis2/pipelines/trellis2_image_to_3d.py
+++ b/trellis2/pipelines/trellis2_image_to_3d.py
@@ -205,7 +205,7 @@ class Trellis2ImageTo3DPipeline(Pipeline):
         flow_model = self.models['sparse_structure_flow_model']
         reso = flow_model.resolution
         in_channels = flow_model.in_channels
-        noise = torch.randn(num_samples, in_channels, reso, reso, reso).to(self.device)
+        noise = torch.randn(num_samples, in_channels, reso, reso, reso).to(device=self.device, dtype=flow_model.dtype)
         sampler_params = {**self.sparse_structure_sampler_params, **sampler_params}
         if self.low_vram:
             flow_model.to(self.device)
@@ -251,7 +251,7 @@ class Trellis2ImageTo3DPipeline(Pipeline):
         """
         # Sample structured latent
         noise = SparseTensor(
-            feats=torch.randn(coords.shape[0], flow_model.in_channels).to(self.device),
+            feats=torch.randn(coords.shape[0], flow_model.in_channels).to(device=self.device, dtype=flow_model.dtype),
             coords=coords,
         )
         sampler_params = {**self.shape_slat_sampler_params, **sampler_params}
@@ -268,12 +268,12 @@ class Trellis2ImageTo3DPipeline(Pipeline):
         if self.low_vram:
             flow_model.cpu()
 
-        std = torch.tensor(self.shape_slat_normalization['std'])[None].to(slat.device)
-        mean = torch.tensor(self.shape_slat_normalization['mean'])[None].to(slat.device)
+        std = torch.tensor(self.shape_slat_normalization['std'])[None].to(device=slat.device, dtype=slat.dtype)
+        mean = torch.tensor(self.shape_slat_normalization['mean'])[None].to(device=slat.device, dtype=slat.dtype)
         slat = slat * std + mean
-        
+
         return slat
-    
+
     def sample_shape_slat_cascade(
         self,
         lr_cond: dict,
@@ -296,7 +296,7 @@ class Trellis2ImageTo3DPipeline(Pipeline):
         """
         # LR
         noise = SparseTensor(
-            feats=torch.randn(coords.shape[0], flow_model_lr.in_channels).to(self.device),
+            feats=torch.randn(coords.shape[0], flow_model_lr.in_channels).to(device=self.device, dtype=flow_model_lr.dtype),
             coords=coords,
         )
         sampler_params = {**self.shape_slat_sampler_params, **sampler_params}
@@ -312,8 +312,8 @@ class Trellis2ImageTo3DPipeline(Pipeline):
         ).samples
         if self.low_vram:
             flow_model_lr.cpu()
-        std = torch.tensor(self.shape_slat_normalization['std'])[None].to(slat.device)
-        mean = torch.tensor(self.shape_slat_normalization['mean'])[None].to(slat.device)
+        std = torch.tensor(self.shape_slat_normalization['std'])[None].to(device=slat.device, dtype=slat.dtype)
+        mean = torch.tensor(self.shape_slat_normalization['mean'])[None].to(device=slat.device, dtype=slat.dtype)
         slat = slat * std + mean
         
         # Upsample
@@ -340,7 +340,7 @@ class Trellis2ImageTo3DPipeline(Pipeline):
         
         # Sample structured latent
         noise = SparseTensor(
-            feats=torch.randn(coords.shape[0], flow_model.in_channels).to(self.device),
+            feats=torch.randn(coords.shape[0], flow_model.in_channels).to(device=self.device, dtype=flow_model.dtype),
             coords=coords,
         )
         sampler_params = {**self.shape_slat_sampler_params, **sampler_params}
@@ -357,10 +357,10 @@ class Trellis2ImageTo3DPipeline(Pipeline):
         if self.low_vram:
             flow_model.cpu()
 
-        std = torch.tensor(self.shape_slat_normalization['std'])[None].to(slat.device)
-        mean = torch.tensor(self.shape_slat_normalization['mean'])[None].to(slat.device)
+        std = torch.tensor(self.shape_slat_normalization['std'])[None].to(device=slat.device, dtype=slat.dtype)
+        mean = torch.tensor(self.shape_slat_normalization['mean'])[None].to(device=slat.device, dtype=slat.dtype)
         slat = slat * std + mean
-        
+
         return slat, hr_resolution
 
     def decode_shape_slat(
@@ -404,12 +404,12 @@ class Trellis2ImageTo3DPipeline(Pipeline):
             sampler_params (dict): Additional parameters for the sampler.
         """
         # Sample structured latent
-        std = torch.tensor(self.shape_slat_normalization['std'])[None].to(shape_slat.device)
-        mean = torch.tensor(self.shape_slat_normalization['mean'])[None].to(shape_slat.device)
+        std = torch.tensor(self.shape_slat_normalization['std'])[None].to(device=shape_slat.device, dtype=shape_slat.dtype)
+        mean = torch.tensor(self.shape_slat_normalization['mean'])[None].to(device=shape_slat.device, dtype=shape_slat.dtype)
         shape_slat = (shape_slat - mean) / std
 
         in_channels = flow_model.in_channels if isinstance(flow_model, nn.Module) else flow_model[0].in_channels
-        noise = shape_slat.replace(feats=torch.randn(shape_slat.coords.shape[0], in_channels - shape_slat.feats.shape[1]).to(self.device))
+        noise = shape_slat.replace(feats=torch.randn(shape_slat.coords.shape[0], in_channels - shape_slat.feats.shape[1]).to(device=self.device, dtype=shape_slat.dtype))
         sampler_params = {**self.tex_slat_sampler_params, **sampler_params}
         if self.low_vram:
             flow_model.to(self.device)
@@ -425,8 +425,8 @@ class Trellis2ImageTo3DPipeline(Pipeline):
         if self.low_vram:
             flow_model.cpu()
 
-        std = torch.tensor(self.tex_slat_normalization['std'])[None].to(slat.device)
-        mean = torch.tensor(self.tex_slat_normalization['mean'])[None].to(slat.device)
+        std = torch.tensor(self.tex_slat_normalization['std'])[None].to(device=slat.device, dtype=slat.dtype)
+        mean = torch.tensor(self.tex_slat_normalization['mean'])[None].to(device=slat.device, dtype=slat.dtype)
         slat = slat * std + mean
         
         return slat


### PR DESCRIPTION
## What

Fix dtype mismatches that cause crashes when running on GPUs without bfloat16 support (compute capability < 8.0, e.g. RTX 20xx, GTX 16xx).

## Why

The pipeline assumes bfloat16 throughout. When models are converted to float16 for older GPUs, three categories of dtype mismatch cause `RuntimeError`:

1. **TimestepEmbedder** hardcodes `float()` for frequency embeddings, but MLP weights may be float16 → `mat1 and mat2 must have the same dtype`
2. **Noise tensors** are created as float32 via `torch.randn().to(device)` without matching the model's dtype → mismatches at the first linear layer
3. **Normalization statistics** (mean/std) default to float32 via `torch.tensor(list)` → arithmetic with float16 latent tensors fails

Additionally, `BiRefNet` (used for background removal) is incompatible with transformers 5.x due to meta device initialization calling `.item()`.

## Changes

| File | Change |
|------|--------|
| `trellis2/models/sparse_structure_flow.py` | Cast timestep frequency embeddings to MLP weight dtype before forward pass |
| `trellis2/pipelines/trellis2_image_to_3d.py` | Cast noise tensors to model dtype (5 sites) and normalization stats to latent dtype (5 sites) |
| `trellis2/pipelines/rembg/BiRefNet.py` | Runtime monkey-patch for transformers 5.x: add missing `all_tied_weights_keys` and skip meta device init |

All changes are backward-compatible — on GPUs with bfloat16 support, dtypes resolve to bfloat16 which matches existing behavior.

## Tested on

- **GPU**: NVIDIA RTX 2060 (6GB VRAM, SM 7.5, no bfloat16)
- **Model**: `microsoft/TRELLIS.2-4B` (smallest variant)
- **Parameters**: `pipeline_type='512'`, `max_num_tokens=32768`, render resolution 512
- **Precision**: `convert_module_to_f16` for flow models (preserves float32 norms), `image_cond_model` kept in float32 (overflows in fp16)
- Pipeline runs end-to-end: sparse structure → shape → texture → decode → render → GLB export

### Sample output
https://github.com/user-attachments/assets/95b0b6ab-8655-42be-a218-df33e7580f59

Generated from `assets/example_image/T.png` on RTX 2060 6GB:

> **Note**: To reproduce, the caller must convert models to float16 via `convert_module_to_f16` and override `model.dtype` from bfloat16 to float16. This PR only fixes the library-side dtype assumptions — the caller-side setup is demonstrated in a [separate example script](https://github.com/kuff/TRELLIS.2/blob/feat/6gb-vram-example/example_6gb.py).