### PR TITLE
Fix layer module reference in image feature extractor

### DIFF
--- a/trellis2/modules/image_feature_extractor.py
+++ b/trellis2/modules/image_feature_extractor.py
@@ -83,7 +83,7 @@ class DinoV3FeatureExtractor:
         hidden_states = self.model.embeddings(image, bool_masked_pos=None)
         position_embeddings = self.model.rope_embeddings(image)
 
-        for i, layer_module in enumerate(self.model.layer):
+        for i, layer_module in enumerate(self.model.model.layer):
             hidden_states = layer_module(
                 hidden_states,
                 position_embeddings=position_embeddings,


### PR DESCRIPTION
DINOv3ViTModel‎ does not have layer attribute, DINOv3ViTEncoder has. We have to access through self.model.model
**References**: [Transformer class implementation](https://github.com/huggingface/transformers/blob/v5.5.0/src/transformers/models/dinov3_vit/modeling_dinov3_vit.py#L514)