### PR TITLE
fix: update DINOv3ViTModel layer access for newer transformers versions

### DIFF
--- a/trellis2/modules/image_feature_extractor.py
+++ b/trellis2/modules/image_feature_extractor.py
@@ -83,7 +83,7 @@ class DinoV3FeatureExtractor:
         hidden_states = self.model.embeddings(image, bool_masked_pos=None)
         position_embeddings = self.model.rope_embeddings(image)
 
-        for i, layer_module in enumerate(self.model.layer):
+        for i, layer_module in enumerate(self.model.encoder.layer):
             hidden_states = layer_module(
                 hidden_states,
                 position_embeddings=position_embeddings,


### PR DESCRIPTION
This PR fixes a compatibility issue with newer versions of the transformers library.
The current implementation assumes that DINOv3ViTModel exposes layers via `self.model.layer`, which is no longer valid in recent versions. This results in an AttributeError:

'DINOv3ViTModel' object has no attribute 'layer'

The fix updates the access path to `self.model.encoder.layer`, which aligns with the current transformers architecture.
This change ensures that the image feature extractor works correctly without requiring users to downgrade their transformers version.