### PR TITLE
docs(o-voxel): fix install command path (o_voxel -> o-voxel)

### DIFF
--- a/o-voxel/README.md
+++ b/o-voxel/README.md
@@ -18,7 +18,7 @@ This library provides an efficient implementation for the instant bidirectional 
 
 ```bash
 git clone -b main https://github.com/microsoft/TRELLIS.2.git --recursive
-pip install TRELLIS.2/o_voxel --no-build-isolation
+pip install TRELLIS.2/o-voxel --no-build-isolation
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary

\`o-voxel/README.md\` line 21 told users to run:

\`\`\`bash
pip install TRELLIS.2/o_voxel --no-build-isolation
\`\`\`

but the directory on disk is \`o-voxel\` (hyphen), so this command fails with a missing-path error. Updated to:

\`\`\`bash
pip install TRELLIS.2/o-voxel --no-build-isolation
\`\`\`

The python *import* name remains \`o_voxel\` (as used elsewhere in the README) — only the pip path/dir changes.

Closes #113

## Testing

Docs-only change; one character.