### PR TITLE
Fix DINOv3 layer access for transformers >= 5.0

### DIFF
--- a/trellis2/modules/image_feature_extractor.py
+++ b/trellis2/modules/image_feature_extractor.py
@@ -83,7 +83,11 @@ class DinoV3FeatureExtractor:
         hidden_states = self.model.embeddings(image, bool_masked_pos=None)
         position_embeddings = self.model.rope_embeddings(image)
 
-        for i, layer_module in enumerate(self.model.layer):
+        # transformers >=5 wraps the DINOv3 encoder under .model (so .layer is at
+        # self.model.model.layer); older versions exposed .layer directly on the
+        # top-level model. Pick whichever exists.
+        encoder = getattr(self.model, "model", self.model)
+        for i, layer_module in enumerate(encoder.layer):
             hidden_states = layer_module(
                 hidden_states,
                 position_embeddings=position_embeddings,


### PR DESCRIPTION
## Summary
- In transformers >= 5.0, `DINOv3ViTModel` wraps its encoder under `.model`, so the layer `ModuleList` lives at `self.model.model.layer` (the inner `model` is `DINOv3ViTEncoder`). Older transformers exposed `.layer` directly on the top-level model.
- `extract_features` in `trellis2/modules/image_feature_extractor.py` only handled the old layout, breaking inference on a fresh install with a current transformers release.
- Pick whichever exists via `getattr(self.model, "model", self.model)` so the path works on both old and new transformers.

## Repro
On a fresh `setup.sh --basic --flash-attn --nvdiffrast --nvdiffrec --cumesh --o-voxel` install (transformers 5.6.2 from PyPI), running `Trellis2ImageTo3DPipeline.run(image)` raises:

```
File "trellis2/modules/image_feature_extractor.py", line 86, in extract_features
    for i, layer_module in enumerate(self.model.layer):
AttributeError: 'DINOv3ViTModel' object has no attribute 'layer'
```

The fix unblocks inference on the latest pinned transformers without affecting older versions.

## Verified
Inference end-to-end on RTX A6000 + transformers 5.6.2 + torch 2.5.1+cu124 produced a valid GLB (504K verts / 945K faces) from a single 1024×1024 PNG input.

## Test plan
- [x] Inference completes and exports GLB on transformers 5.6.2
- [ ] No-op on transformers <5 where `self.model.layer` already exists (`getattr` returns the same model object, behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)