### PR TITLE
Fix stale seqlen cache in cascade reduce() (MPS crash, CUDA latent)

### DIFF
--- a/trellis2/modules/sparse/basic.py
+++ b/trellis2/modules/sparse/basic.py
@@ -267,7 +267,7 @@ class VarLenTensor:
     def reduce(self, op: str, dim: Optional[Union[int, Tuple[int,...]]] = None, keepdim: bool = False) -> torch.Tensor:
         if isinstance(dim, int):
             dim = (dim,)
-        
+
         if op =='mean':
             red = self.feats.mean(dim=dim, keepdim=keepdim)
         elif op =='sum':
@@ -276,12 +276,65 @@ class VarLenTensor:
             red = self.feats.prod(dim=dim, keepdim=keepdim)
         else:
             raise ValueError(f"Unsupported reduce operation: {op}")
-        
+
         if dim is None or 0 in dim:
             return red
-        
-        red = torch.segment_reduce(red, reduce=op, lengths=self.seqlen)
-        return red
+
+        # Defensive cache validation: in the cascade Shape-SLat sampler's
+        # CFG-rescale path (classifier_free_guidance_mixin.std_pos = ...),
+        # x_0_pos is derived from x_t via an elementwise chain that
+        # propagates _spatial_cache by reference (see replace() /
+        # __merge_sparse_cache below). If the inherited cached `seqlen`
+        # was computed at a different scale than x_0_pos.feats, the
+        # invariant sum(seqlen) == feats.shape[0] no longer holds.
+        # CUDA's segment_reduce kernel silently consumes the mismatch;
+        # the CPU path (MPS fallback) raises RuntimeError. Recompute
+        # lengths from coords (authoritative) and evict the stale
+        # cache entries so subsequent reads stay correct.
+        lengths = self.seqlen
+        n_data = red.shape[0]
+        if int(lengths.sum().item()) != n_data:
+            fresh = None
+            coords = getattr(self, 'coords', None)
+            if coords is not None and coords.shape[0] == n_data:
+                batch_size = int(coords[:, 0].max().item()) + 1 if coords.shape[0] > 0 else 1
+                fresh = torch.bincount(coords[:, 0].long(), minlength=batch_size).to(
+                    dtype=torch.long, device=red.device
+                )
+            if fresh is None or int(fresh.sum().item()) != n_data:
+                fresh = torch.tensor(
+                    [l.stop - l.start for l in self.layout],
+                    dtype=torch.long, device=red.device,
+                )
+            if hasattr(self, '_spatial_cache') and hasattr(self, '_scale'):
+                try:
+                    scale_key = str(self._scale)
+                    slot = self._spatial_cache.get(scale_key, {})
+                    for k in ('seqlen', 'cum_seqlen', 'batch_boardcast_map', 'layout'):
+                        slot.pop(k, None)
+                except Exception:
+                    pass
+            elif hasattr(self, '_cache'):
+                try:
+                    for k in ('seqlen', 'cum_seqlen', 'batch_boardcast_map'):
+                        self._cache.pop(k, None)
+                except Exception:
+                    pass
+            lengths = fresh
+            if int(lengths.sum().item()) != n_data:
+                raise RuntimeError(
+                    f"VarLenTensor.reduce: cannot reconcile seqlen "
+                    f"sum({int(lengths.sum().item())}) with data.size(0)={n_data}. "
+                    f"layout has {len(self.layout)} segments."
+                )
+
+        # torch.segment_reduce has no Metal kernel; PyTorch's auto fallback
+        # is racy on cascade-sized workloads. Run explicitly on CPU and
+        # copy back. No-op on CUDA / CPU.
+        if red.device.type == 'mps':
+            reduced = torch.segment_reduce(red.cpu(), reduce=op, lengths=lengths.cpu())
+            return reduced.to(red.device)
+        return torch.segment_reduce(red, reduce=op, lengths=lengths)
     
     def mean(self, dim: Optional[Union[int, Tuple[int,...]]] = None, keepdim: bool = False) -> torch.Tensor:
         return self.reduce(op='mean', dim=dim, keepdim=keepdim)


### PR DESCRIPTION
## Summary

`VarLenTensor.reduce()` in `trellis2/modules/sparse/basic.py` reads `self.seqlen`
from a per-scale `_spatial_cache` slot that, in the cascade Shape-SLat sampler's
CFG-rescale path (`x_0_pos.std(...)`), can hold a value left over from the parent
tensor's scale. When that happens, `sum(seqlen) != feats.shape[0]`.

* **MPS (Apple Silicon)** — `torch.segment_reduce` has no Metal kernel and PyTorch falls back to CPU. The CPU path strictly enforces `sum(lengths) == data.size(0)` and raises `RuntimeError`. The cascade Shape-SLat pass aborts at ~step 3.
* **CUDA** — the existing call would not raise the same check in our reading. If the root-cause hypothesis below is correct, the CFG-rescale `std()` in cascade mode would return numerically wrong values silently. Easy to verify by adding `assert lengths.sum() == data.size(0)` before the existing call. We do not have CUDA hardware to confirm.

Closes the Apple-Silicon side of #74.

## Repro (MPS)

```bash
git clone https://github.com/shivampkumar/trellis-mac
cd trellis-mac && bash setup.sh && source .venv/bin/activate
PYTORCH_ENABLE_MPS_FALLBACK=1 python generate.py path/to/image.png \
  --pipeline-type 1024_cascade --texture-size 2048 --steps 16
```

Aborts ~step 3 of the cascade Shape-SLat pass with:

```
File "trellis2/modules/sparse/basic.py", line 283, in reduce
    red = torch.segment_reduce(red, reduce=op, lengths=self.seqlen)
RuntimeError: segment_reduce(): Expected all rows of lengths along axis
to sum to data.size(lengths.dim()-1) when !unsafe.
```

## Root cause hypothesis

1. `SparseTensor.seqlen` is cached in `_spatial_cache[str(self._scale)]['seqlen']` (`basic.py:543-548`).
2. `SparseTensor.replace()` (`basic.py:671-676`) constructs the new tensor with `spatial_cache=self._spatial_cache` — same dict reference, same scale key. `__merge_sparse_cache()` (`basic.py:705-715`) merges across two sparse operands.
3. In the cascade Shape-SLat pass, `flow_euler.sample_once` derives `x_0_pos` from `_pred_to_xstart(x_t, t, pred_pos)`, an elementwise chain over `x_t` and the model output. The result inherits `x_t`'s `_spatial_cache`.
4. CFG-rescale (`classifier_free_guidance_mixin.py:23`) calls `x_0_pos.std(dim=list(range(1, x_0_pos.ndim)), keepdim=True)`, which lands in `VarLenTensor.reduce`. `self.seqlen` returns the inherited cached value, which no longer matches `x_0_pos.feats.shape[0]` for this scale.

The base Shape-SLat pass does not exercise the same scale interaction and stays valid.

## Fix

Two defensive layers in `VarLenTensor.reduce()`:

1. **Cache validation** — if `sum(lengths) != data.size(0)`, recompute `lengths` from `coords` (the authoritative source) and evict the stale `seqlen / cum_seqlen / batch_boardcast_map / layout` from the per-scale cache. On CUDA this branch is a no-op in the happy path; it only fires in the same stale-cache case that would silently miscompute today.
2. **Explicit MPS → CPU fallback** for `segment_reduce` — bypasses the auto fallback's noisier device-sync path. Also gives a ~5× speedup per cascade step (358s → ~50s) in our benchmark, independent of correctness.

## Benchmark (M3 Pro 18GB, `astronaut.jpeg`, `--pipeline-type 1024_cascade --texture-size 2048 --steps 16`)

| Stage | Before | After |
|---|---|---|
| Sparse structure (16 steps) | 2:52 | 2:44 |
| Shape SLat — base pass (16 steps) | 1:15 | 0:54 |
| **Shape SLat — cascade pass (16 steps)** | **crash @ step 3** | **10:47 ✓** |
| Texture SLat (16 steps) | n/a | 6:17 |
| Mesh + xatlas + Metal bake | n/a | 0:25 |
| **End-to-end** | crash | **~24 min generation + 25s bake** |

Output: 21 MB GLB / 242 MB OBJ, 132K vert / 192K face, 2K PBR (base color + metallic + roughness + alpha).

## Not verified

- CUDA regression on H100 / consumer cards — no hardware. The CUDA path is identical to before in the happy case; only behavior is in the stale-cache branch where it now uses a valid `lengths` instead of a stale one.
- `1536_cascade` — only `1024_cascade` was end-to-end-verified. The cache logic is scale-agnostic but the 1536 path has separate reports (see related).

## Related cascade-pass reports

| Repo | Issue | Symptom | Plausibly same root |
|---|---|---|---|
| visualbruno/ComfyUI-Trellis2 | [#113](https://github.com/visualbruno/ComfyUI-Trellis2/issues/113) | `1536_cascade` abort, RTX 4090, `spatial2channel.py:77` OOB | different file, possibly related fragility |
| visualbruno/ComfyUI-Trellis2 | [#98](https://github.com/visualbruno/ComfyUI-Trellis2/issues/98)  | `1024_cascade` / `1536_cascade`, RTX 5090, `max(): Expected reduction dim 0 to have non-zero size` | empty-tensor downstream of stale cache? |
| visualbruno/ComfyUI-Trellis2 | [#31](https://github.com/visualbruno/ComfyUI-Trellis2/issues/31)  | cascade `sparse_structure_resolution=64` edge case | unrelated, but cascade-path |
| pytorch/pytorch | [#186540](https://github.com/pytorch/pytorch/issues/186540) | native Metal `segment_reduce` kernel (open) | will obsolete layer 2 once merged |

---

_(感谢 TRELLIS.2 团队的开源——repro 在 macOS 上 100% 可复现，方便的话可以在 CUDA 上跑一下 cascade 输出比对，验证 silent miscompute 的影响范围。)_
