### PR TITLE
Texturing: make the keep-existing-UVs path reachable (and non-crashing once it is)

### DIFF
--- a/trellis2/pipelines/trellis2_texturing.py
+++ b/trellis2/pipelines/trellis2_texturing.py
@@ -117,7 +117,9 @@ class Trellis2TexturingPipeline(Pipeline):
         vertices[:, 1] = -vertices[:, 2]
         vertices[:, 2] = tmp
         assert np.all(vertices >= -0.5) and np.all(vertices <= 0.5), 'vertices out of range'
-        return trimesh.Trimesh(vertices=vertices, faces=mesh.faces, process=False)
+        # Carry the visual through so postprocess_mesh's keep-existing-UVs branch is reachable
+        # (vertex order is unchanged, so per-vertex UVs stay valid).
+        return trimesh.Trimesh(vertices=vertices, faces=mesh.faces, visual=mesh.visual, process=False)
 
     def preprocess_image(self, input: Image.Image) -> Image.Image:
         """
@@ -291,9 +293,11 @@ class Trellis2TexturingPipeline(Pipeline):
         resolution: int = 1024,
         texture_size: int = 1024,
     ) -> trimesh.Trimesh:
-        vertices = mesh.vertices
-        faces = mesh.faces
-        normals = mesh.vertex_normals
+        # Copies: trimesh caches (vertex_normals) are read-only, and the axis swap below
+        # writes in place — only the uv-unwrap branch replaced these with fresh arrays.
+        vertices = np.array(mesh.vertices)
+        faces = np.array(mesh.faces)
+        normals = np.array(mesh.vertex_normals)
         vertices_torch = torch.from_numpy(vertices).float().cuda()
         faces_torch = torch.from_numpy(faces).int().cuda()
         if hasattr(mesh, 'visual') and hasattr(mesh.visual, 'uv') and mesh.visual.uv is not None:


### PR DESCRIPTION
## Problem

`Trellis2TexturingPipeline.postprocess_mesh` implements a keep-existing-UVs branch, but it is **unreachable via `run()`**: `preprocess_mesh` rebuilds the mesh as `trimesh.Trimesh(vertices=vertices, faces=mesh.faces, process=False)` and drops `mesh.visual`, so by the time `postprocess_mesh` checks `mesh.visual.uv`, the UVs are always gone and every input falls into the uv-unwrap branch. The shipped "texture an existing mesh preserving its UVs" capability silently never engages.

## Fix

1. **`preprocess_mesh`**: pass `visual=mesh.visual` through the rebuilt `Trimesh`. The rebuild doesn't change vertex order (only positions), so per-vertex UVs remain valid.
2. **`postprocess_mesh`**: copy `vertices`/`faces`/`normals` with `np.array()` up front. `mesh.vertex_normals` is a read-only trimesh cache, and the glTF axis swap at the end writes it in place (`normals[:, 1], normals[:, 2] = ...`). Today only the uv-unwrap branch runs, and it happens to replace `normals` with a fresh indexed array — so this second bug is latent until fix (1) makes the UV-preserve branch reachable, at which point it crashes. The two fixes belong in the same PR.

## Evidence

With these changes, re-texturing an existing UV-mapped mesh preserves its UVs bit-identically — we measured max UV delta 0.0 between input and output in production use (Apple Silicon port work, https://github.com/xocialize/trellis2-apple).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
