### PR TITLE
Fix KeyError in pipelines.from_pretrained when it is the first touch of the module

### DIFF
--- a/trellis2/pipelines/__init__.py
+++ b/trellis2/pipelines/__init__.py
@@ -32,6 +32,7 @@ def from_pretrained(path: str):
     """
     import os
     import json
+    import sys
     is_local = os.path.exists(f"{path}/pipeline.json")
 
     if is_local:
@@ -42,7 +43,9 @@ def from_pretrained(path: str):
 
     with open(config_file, 'r') as f:
         config = json.load(f)
-    return globals()[config['name']].from_pretrained(path)
+    # getattr routes through the module's lazy __getattr__; globals() bypasses it and
+    # raises KeyError when from_pretrained is the first touch of the module.
+    return getattr(sys.modules[__name__], config['name']).from_pretrained(path)
 
 
 # For PyLance


### PR DESCRIPTION
## Repro

```python
from trellis2 import pipelines
pipelines.from_pretrained("microsoft/TRELLIS.2-image-to-3D-4B")
# KeyError: 'Trellis2ImageTo3DPipeline'
```

Fails whenever `from_pretrained` is the **first touch of the module**. `trellis2/pipelines/__init__.py` uses a lazy `__getattr__` that populates `globals()` on first attribute access, but `from_pretrained` looks the class up with `globals()[config['name']]` — which bypasses `__getattr__` entirely. It only works if something else (e.g. an earlier `pipelines.Trellis2ImageTo3DPipeline` reference) already triggered the lazy import.

## Fix

Route the lookup through the module's own lazy loader:

```python
return getattr(sys.modules[__name__], config['name']).from_pretrained(path)
```

`getattr` on the module object hits `__getattr__`, triggering the intended lazy import. No behavior change when the class is already loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
