### PR TITLE
fix: add GPU Docker runtime support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.gitignore
+.dockerignore
+Dockerfile
+compose.yaml
+README.md
+.venv
+__pycache__
+*.py[cod]
+*.egg-info
+build
+dist
+models
+outputs
+*.mp4
+*.glb

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Runtime data created by compose.yaml.
+/models/
+/outputs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,9 @@ RUN python3 -m pip install \
         torch==2.6.0 torchvision==0.21.0 \
         --index-url https://download.pytorch.org/whl/cu124 \
     && python3 -m pip install \
-        imageio imageio-ffmpeg tqdm easydict opencv-python-headless==4.10.0.84 ninja trimesh \
+        imageio imageio-ffmpeg tqdm easydict opencv-python-headless==4.10.0.84 Pillow==9.5.0 ninja trimesh \
         transformers gradio==6.0.1 tensorboard pandas lpips zstandard \
         kornia timm \
-    && python3 -m pip install pillow-simd \
     && python3 -m pip install git+https://github.com/EasternJournalist/utils3d.git@9a4eb15e4021b67b12c460c7057d642626897ec8 \
     && python3 -m pip install flash-attn==2.7.3 --no-build-isolation \
     && git clone --depth 1 --branch v0.4.0 https://github.com/NVlabs/nvdiffrast.git /tmp/nvdiffrast \
@@ -70,11 +69,6 @@ RUN python3 -m pip install \
     && python3 -m pip install /tmp/flexgemm --no-build-isolation \
     && python3 -m pip install ./o-voxel --no-build-isolation \
     && rm -rf /tmp/nvdiffrast /tmp/nvdiffrec /tmp/cumesh /tmp/flexgemm
-
-# Gradio 6.0.1 requires Pillow 9.5's WebP API. The upstream pillow-simd step
-# overlays Pillow rather than replacing it, so cleanly replace both packages.
-RUN python3 -m pip uninstall -y Pillow pillow-simd \
-    && python3 -m pip install Pillow==9.5.0
 
 COPY . /workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,85 @@
+# CUDA 12.4 matches the PyTorch wheel used by the upstream setup script.
+# The host only needs a compatible NVIDIA driver plus NVIDIA Container Toolkit.
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TORCH_CUDA_ARCH_LIST=8.9
+ARG MAX_JOBS=4
+
+ENV TZ=Etc/UTC \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    CUDA_HOME=/usr/local/cuda \
+    TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST} \
+    MAX_JOBS=${MAX_JOBS} \
+    HF_HOME=/models/huggingface \
+    TRANSFORMERS_CACHE=/models/huggingface/transformers \
+    OPENCV_IO_ENABLE_OPENEXR=1 \
+    GRADIO_SERVER_NAME=0.0.0.0 \
+    GRADIO_SERVER_PORT=7860 \
+    PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        ffmpeg \
+        gcc-11 \
+        g++-11 \
+        git \
+        libegl1 \
+        libgl1 \
+        libglib2.0-0 \
+        libjpeg-dev \
+        python3 \
+        python3-dev \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 110 \
+    && python3 -m pip install --upgrade pip setuptools wheel
+
+WORKDIR /workspace
+
+# The dependency layer needs only o-voxel. Keeping application source out of
+# this layer lets Docker reuse the expensive CUDA-extension build when app code
+# or the Compose configuration changes.
+COPY o-voxel /workspace/o-voxel
+
+# Keep these commands in the same order as setup.sh, excluding conda and sudo.
+RUN python3 -m pip install \
+        torch==2.6.0 torchvision==0.21.0 \
+        --index-url https://download.pytorch.org/whl/cu124 \
+    && python3 -m pip install \
+        imageio imageio-ffmpeg tqdm easydict opencv-python-headless==4.10.0.84 ninja trimesh \
+        transformers gradio==6.0.1 tensorboard pandas lpips zstandard \
+        kornia timm \
+    && python3 -m pip install pillow-simd \
+    && python3 -m pip install git+https://github.com/EasternJournalist/utils3d.git@9a4eb15e4021b67b12c460c7057d642626897ec8 \
+    && python3 -m pip install flash-attn==2.7.3 --no-build-isolation \
+    && git clone --depth 1 --branch v0.4.0 https://github.com/NVlabs/nvdiffrast.git /tmp/nvdiffrast \
+    && python3 -m pip install /tmp/nvdiffrast --no-build-isolation \
+    && git clone --depth 1 --branch renderutils https://github.com/JeffreyXiang/nvdiffrec.git /tmp/nvdiffrec \
+    && python3 -m pip install /tmp/nvdiffrec --no-build-isolation \
+    && git clone --depth 1 --recurse-submodules https://github.com/JeffreyXiang/CuMesh.git /tmp/cumesh \
+    && python3 -m pip install /tmp/cumesh --no-build-isolation \
+    && git clone --depth 1 --recurse-submodules https://github.com/JeffreyXiang/FlexGEMM.git /tmp/flexgemm \
+    && python3 -m pip install /tmp/flexgemm --no-build-isolation \
+    && python3 -m pip install ./o-voxel --no-build-isolation \
+    && rm -rf /tmp/nvdiffrast /tmp/nvdiffrec /tmp/cumesh /tmp/flexgemm
+
+# Gradio 6.0.1 requires Pillow 9.5's WebP API. The upstream pillow-simd step
+# overlays Pillow rather than replacing it, so cleanly replace both packages.
+RUN python3 -m pip uninstall -y Pillow pillow-simd \
+    && python3 -m pip install Pillow==9.5.0
+
+COPY . /workspace
+
+RUN mkdir -p /models/huggingface /workspace/outputs
+
+EXPOSE 7860
+
+CMD ["python3", "app.py"]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,58 @@ Data processing is streamlined for instant conversions that are fully **renderin
         --nvdiffrec             Install nvdiffrec
     ```
 
+### Docker (NVIDIA GPU)
+
+The included Docker image installs the same CUDA 12.4 / PyTorch 2.6 dependency
+stack as `setup.sh`, including all required CUDA extensions. It is configured
+for an RTX 4090 (compute capability 8.9).
+
+The host requires Docker, NVIDIA Container Toolkit, and a driver compatible
+with CUDA 12.4. The build compiles several CUDA extensions, so ensure the
+Docker data directory has at least 25 GiB free (in addition to space for model
+weights). Check this with `docker info --format '{{.DockerRootDir}}'` and
+`df -h <that-directory>`. Build the image once:
+
+```sh
+docker compose build
+```
+
+Start the image-to-3D demo and open <http://localhost:7860>:
+
+```sh
+docker compose up
+```
+
+Model weights are downloaded from Hugging Face on first start into `./models/`
+and are reused across containers. Generated files can be written to
+`./outputs/`. To run a command such as the minimal example instead of the web
+demo:
+
+```sh
+docker compose run --rm trellis2 python3 example.py
+```
+
+To use a Hugging Face access token without saving it in the repository, export
+it in the shell that starts Compose:
+
+```sh
+export HF_TOKEN=hf_your_token_here
+docker compose up
+```
+
+TRELLIS.2 also downloads the gated DINOv3 image encoder. Before the first run,
+sign in to Hugging Face with the account that owns `HF_TOKEN` and accept the
+access conditions at
+[`facebook/dinov3-vitl16-pretrain-lvd1689m`](https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m).
+The token needs read access to that model.
+
+The image uses `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` to reduce
+allocation fragmentation. TRELLIS.2 officially requires at least 24 GB of GPU
+memory; a 24 GB RTX 4090 meets that minimum, although high resolutions or an
+active graphical desktop can still cause an out-of-memory error. Begin at
+512³, close other GPU-intensive programs, and increase the resolution only
+after a successful run.
+
 ## 📦 Pretrained Weights
 
 The pretrained model **TRELLIS.2-4B** is available on Hugging Face. Please refer to the model card there for more details.

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,30 @@
+services:
+  trellis2:
+    build:
+      context: .
+      args:
+        # RTX 4090 (Ada) compute capability. Keeping this precise reduces
+        # extension build time and image size.
+        TORCH_CUDA_ARCH_LIST: "8.9"
+        MAX_JOBS: "4"
+    image: trellis2:cuda12.4
+    gpus: all
+    ports:
+      - "7860:7860"
+    environment:
+      GRADIO_SERVER_NAME: 0.0.0.0
+      GRADIO_SERVER_PORT: "7860"
+      PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+      HF_HOME: /models/huggingface
+      OPENCV_IO_ENABLE_OPENEXR: "1"
+      # Read from the host shell; never put a token directly in this file.
+      HF_TOKEN: ${HF_TOKEN:-}
+    volumes:
+      # Code is mounted for easy iteration. Remove this line to run precisely
+      # the source snapshot baked into the image.
+      - .:/workspace
+      # Checkpoints download here on first launch and survive container rebuilds.
+      - ./models:/models
+      - ./outputs:/workspace/outputs
+    shm_size: 8gb
+    command: python3 app.py

--- a/trellis2/modules/image_feature_extractor.py
+++ b/trellis2/modules/image_feature_extractor.py
@@ -83,7 +83,13 @@ class DinoV3FeatureExtractor:
         hidden_states = self.model.embeddings(image, bool_masked_pos=None)
         position_embeddings = self.model.rope_embeddings(image)
 
-        for i, layer_module in enumerate(self.model.layer):
+        # Transformers 5 wraps the encoder in ``model``; older releases expose
+        # the same layer list directly on DINOv3ViTModel.
+        layers = getattr(self.model, 'layer', None)
+        if layers is None:
+            layers = self.model.model.layer
+
+        for i, layer_module in enumerate(layers):
             hidden_states = layer_module(
                 hidden_states,
                 position_embeddings=position_embeddings,

--- a/trellis2/trainers/flow_matching/mixins/image_conditioned.py
+++ b/trellis2/trainers/flow_matching/mixins/image_conditioned.py
@@ -85,7 +85,13 @@ class DinoV3FeatureExtractor:
         hidden_states = self.model.embeddings(image, bool_masked_pos=None)
         position_embeddings = self.model.rope_embeddings(image)
 
-        for i, layer_module in enumerate(self.model.layer):
+        # Transformers 5 wraps the encoder in ``model``; older releases expose
+        # the same layer list directly on DINOv3ViTModel.
+        layers = getattr(self.model, 'layer', None)
+        if layers is None:
+            layers = self.model.model.layer
+
+        for i, layer_module in enumerate(layers):
             hidden_states = layer_module(
                 hidden_states,
                 position_embeddings=position_embeddings,


### PR DESCRIPTION
## Summary

  Adds a Docker/Compose runtime for GPU-backed TRELLIS.2 inference.

  - Adds a CUDA 12.4 image with PyTorch 2.6 and the required CUDA extensions.
  - Adds a Compose service with NVIDIA GPU access, Gradio port forwarding, persistent Hugging Face cache, and output mounts.
  - Documents Docker usage, Hugging Face token forwarding, and DINOv3 gated-model access.
  - Pins compatible OpenCV and Pillow releases for EXR environment-map loading and Gradio WebP support.
  - Updates DINOv3 feature extraction to support both legacy and Transformers 5 encoder layouts.
  - Keeps generated models and outputs out of Git.

  ## Validation

  - Built the Docker image successfully.
  - Verified CUDA access from the container on an RTX 4090.
  - Verified FlashAttention, nvdiffrast, and O-Voxel imports.
  - Verified OpenEXR decoding of the bundled HDR environment map.
  - Verified DINOv3 feature extraction on `cuda:0`.
