### PR TITLE
Fix broken resume in encode_ss_latent.py and correct data_toolkit README commands

### DIFF
--- a/data_toolkit/README.md
+++ b/data_toolkit/README.md
@@ -69,15 +69,15 @@ python data_toolkit/dump_mesh.py <SUBSET> --root <ROOT> [--rank <RANK> --world_s
 # Dump PBR Textures
 python data_toolkit/dump_pbr.py <SUBSET> --root <ROOT> [--rank <RANK> --world_size <WORLD_SIZE>]
 
-# Get statisitics of the asset
-python asset_stats.py --root <ROOT> [--rank <RANK> --world_size <WORLD_SIZE>]
+# Get statistics of the asset
+python data_toolkit/asset_stats.py --root <ROOT> [--rank <RANK> --world_size <WORLD_SIZE>]
 ```
 
 **Example:**
 ```bash
 python data_toolkit/dump_mesh.py ObjaverseXL --root datasets/ObjaverseXL_sketchfab
 python data_toolkit/dump_pbr.py ObjaverseXL --root datasets/ObjaverseXL_sketchfab
-python asset_stats.py --root datasets/ObjaverseXL_sketchfab
+python data_toolkit/asset_stats.py --root datasets/ObjaverseXL_sketchfab
 ```
 
 **Update Metadata:**
@@ -97,7 +97,7 @@ python data_toolkit/voxelize_pbr.py <SUBSET> --root <ROOT> [--rank <RANK> --worl
 ```
 
 **Arguments:**
-- `RESOLUTION`: Target resolutions for O-Voxels, comma-separated (e.g., `256,512,1024`). Default is `256`.
+- `RESOLUTION`: Target resolutions for O-Voxels, comma-separated (e.g., `256,512,1024`). Default is `256` for `dual_grid.py` and `1024` for `voxelize_pbr.py`.
 
 **Example:**
 Convert `ObjaverseXL` to resolutions 256, 512, and 1024:
@@ -155,11 +155,11 @@ Render multi-view images to train the image-conditioned generator.
 *Note: This process may utilize the CPU.*
 
 ```bash
-python data_toolkit/render_cond.py <SUBSET> --root <ROOT> [--num_views <NUM_VIEWS>] [--rank <RANK> --world_size <WORLD_SIZE>]
+python data_toolkit/render_cond.py <SUBSET> --root <ROOT> [--num_cond_views <NUM_COND_VIEWS>] [--rank <RANK> --world_size <WORLD_SIZE>]
 ```
 
 **Arguments:**
-- `NUM_VIEWS`: Number of views to render per asset. Default is `16`.
+- `NUM_COND_VIEWS`: Number of views to render per asset. Default is `16`.
 
 **Example:**
 ```bash

--- a/data_toolkit/encode_ss_latent.py
+++ b/data_toolkit/encode_ss_latent.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
                         help='Filter objects with aesthetic score lower than this value')
     parser.add_argument('--resolution', type=int, default=64,
                         help='Sparse voxel resolution')
-    parser.add_argument('--shape_latent_name', type=str, default=None,
+    parser.add_argument('--shape_latent_name', type=str, required=True,
                         help='Name of the shape latent files')
     parser.add_argument('--enc_pretrained', type=str, default='microsoft/TRELLIS-image-large/ckpts/ss_enc_conv3d_16l8_fp16',
                         help='Pretrained encoder model')
@@ -98,7 +98,7 @@ if __name__ == '__main__':
     records = []
     
     # filter out objects that are already processed
-    sha256_list = os.listdir(os.path.join(opt.ss_latent_root, 'ss_latents'))
+    sha256_list = os.listdir(os.path.join(opt.ss_latent_root, 'ss_latents', latent_name))
     sha256_list = [os.path.splitext(f)[0] for f in sha256_list if f.endswith('.npz')]
     for sha256 in sha256_list:
         records.append({'sha256': sha256, 'ss_latent_encoded': True})


### PR DESCRIPTION
## Summary

This PR fixes a code bug that silently discards completed work in the dataset-preparation pipeline, plus several README command errors in `data_toolkit/` that make the documented workflow fail as written.

### 1. `encode_ss_latent.py`: resume/skip logic never finds finished work

The skip list is built from the top-level directory:

```python
sha256_list = os.listdir(os.path.join(opt.ss_latent_root, 'ss_latents'))
sha256_list = [os.path.splitext(f)[0] for f in sha256_list if f.endswith('.npz')]
```

but `saver()` writes latents one level deeper, to `ss_latents/<latent_name>/<sha256>.npz`. The top-level `ss_latents/` only ever contains the `<latent_name>` subdirectory, so the `.npz` filter always produces an empty list, every rerun prints `Found 0 processed objects`, and the script re-encodes the entire dataset after any interruption.

`encode_shape_latent.py` already checks the nested `shape_latents/<latent_name>/` path for exactly the same purpose; this change applies the same convention. Notes on safety:
- The nested directory is guaranteed to exist: it is created by the `os.makedirs(..., 'new_records', exist_ok=True)` call at startup.
- The `new_records` subdirectory and `metadata.csv` inside it are excluded by the existing `.endswith('.npz')` filter.
- `build_metadata.py` merges part CSVs via `combine_first` keyed on `sha256`, so pre-existing objects being recorded again is harmless.

### 2. `encode_ss_latent.py`: `--shape_latent_name` declared optional but required in practice

With the default `None`, this line crashes before any work starts:

```python
os.path.join(opt.shape_latent_root, 'shape_latents', opt.shape_latent_name, 'metadata.csv')
# TypeError: join() argument must be str, bytes, or os.PathLike object, not 'NoneType'
```

The README already documents the flag as mandatory (it appears outside the optional brackets in Step 6). Marking it `required=True` replaces the cryptic `TypeError` with a clear argparse error message.

### 3. `data_toolkit/README.md` command corrections

- **Step 4:** `python asset_stats.py ...` (2 places) lacks the `data_toolkit/` prefix used by every other command, so it fails with `can't open file` when run from the repo root as documented. Also fixes the "statisitics" typo on the adjacent comment line.
- **Step 7:** documented flag `--num_views` does not exist; `render_cond.py` defines `--num_cond_views`, so the documented invocation exits with `unrecognized arguments`.
- **Step 5:** the stated default resolution of `256` only applies to `dual_grid.py`; `voxelize_pbr.py` defaults to `1024`. Following the docs without an explicit `--resolution` produces mismatched `dual_grid_256` / `pbr_voxels_1024` artifacts. Documented the actual defaults (no behavior change).

## Test plan

- [x] `python -m py_compile data_toolkit/encode_ss_latent.py` passes
- [x] Verified the save path vs. skip-list path by inspection, and that `encode_shape_latent.py` uses the nested path for the same check
- [x] Verified argparse definitions in `render_cond.py`, `dual_grid.py`, and `voxelize_pbr.py` against the README
- [ ] Not run end-to-end on a prepared dataset (requires downloaded ObjaverseXL data + GPU); changes are limited to a directory path, an argparse flag, and documentation

